### PR TITLE
Add macaddr to list of inet types

### DIFF
--- a/lib/inet.ex
+++ b/lib/inet.ex
@@ -3,7 +3,7 @@ defmodule Inet do
 
   @behaviour Postgrex.Extension
 
-  @inet ~w(inet cidr)
+  @inet ~w(inet cidr macaddr)
 
   @moduledoc """
   A Postgrex.Extension enabling the use of the inet data type.


### PR DESCRIPTION
Without it in the list, MAC addresses aren't marshalled into a format that Postgrex will accept.
